### PR TITLE
Use the gmp module from the runtime

### DIFF
--- a/dev.edfloreshz.Calculator.json
+++ b/dev.edfloreshz.Calculator.json
@@ -31,17 +31,6 @@
   },
   "modules": [
     {
-      "name": "gmp",
-      "buildsystem": "autotools",
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz",
-          "sha256": "a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898"
-        }
-      ]
-    },
-    {
       "name": "mpfr",
       "buildsystem": "autotools",
       "sources": [


### PR DESCRIPTION
Freedesktop runtime version 24.08 already provides the gmp module.

In most cases, you don't need to build this module separately, unless your project requires a specific version or a custom configuration.

Fixes: https://github.com/flathub/dev.edfloreshz.Calculator/issues/5