### PR TITLE
 Use mpfr module from runtime and more

### DIFF
--- a/dev.edfloreshz.Calculator.json
+++ b/dev.edfloreshz.Calculator.json
@@ -19,6 +19,15 @@
     "--talk-name=com.system76.CosmicSettingsDaemon",
     "--filesystem=xdg-config/cosmic:rw"
   ],
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig",
+    "/share/aclocal",
+    "/share/doc",
+    "/share/man",
+    "*.la",
+    "*.a"
+  ],
   "build-options": {
     "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm20/bin",
     "env": {

--- a/dev.edfloreshz.Calculator.json
+++ b/dev.edfloreshz.Calculator.json
@@ -31,17 +31,6 @@
   },
   "modules": [
     {
-      "name": "mpfr",
-      "buildsystem": "autotools",
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://www.mpfr.org/mpfr-4.2.1/mpfr-4.2.1.tar.xz",
-          "sha256": "277807353a6726978996945af13e52829e3abd7a9a5b7fb2793894e18f1fcbb2"
-        }
-      ]
-    },
-    {
       "name": "intltool",
       "buildsystem": "autotools",
       "sources": [

--- a/dev.edfloreshz.Calculator.json
+++ b/dev.edfloreshz.Calculator.json
@@ -2,13 +2,13 @@
   "$schema": "https://raw.githubusercontent.com/flatpak/flatpak-builder/main/data/flatpak-manifest.schema.json",
   "id": "dev.edfloreshz.Calculator",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "24.08",
+  "runtime-version": "25.08",
   "base": "com.system76.Cosmic.BaseApp",
   "base-version": "stable",
   "sdk": "org.freedesktop.Sdk",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.rust-stable",
-    "org.freedesktop.Sdk.Extension.llvm18"
+    "org.freedesktop.Sdk.Extension.llvm20"
   ],
   "command": "cosmic-ext-calculator",
   "finish-args": [
@@ -20,7 +20,7 @@
     "--filesystem=xdg-config/cosmic:rw"
   ],
   "build-options": {
-    "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm18/bin",
+    "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm20/bin",
     "env": {
       "CARGO_HOME": "/run/build/calculator/cargo",
       "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER": "clang",


### PR DESCRIPTION
### Update runtime to 25.08

- Update runtime to 25.08
- Update llvm version to llvm20

### Use mpfr module from runtime

Freedesktop runtime version **25.08** appears to provide the **mpfr** module.

In most cases, you don't need to build this module separately, unless your project
requires a specific version or a custom configuration.

Fixes: https://github.com/flathub/dev.edfloreshz.Calculator/issues/7

### Reduce the Flatpak size

Use cleanup commands to remove development-related files.